### PR TITLE
fix(product list): Changed onClick so its on the description of the p…

### DIFF
--- a/src/app/productlists/page.js
+++ b/src/app/productlists/page.js
@@ -152,11 +152,10 @@ export default function ProductList() {
                   <img
                     alt={product.imagealt}
                     src={product.imagesrc}
-                    onClick={() => handleCardClick(product.id)}
                     className="h-full w-full object-cover object-center lg:h-full lg:w-full"
                   />
                   {hoveredProductId === product.id && (
-                    <div className="absolute inset-0 bg-gray-800 text-white p-4 rounded-lg flex items-center justify-center opacity-90">
+                    <div className="absolute inset-0 bg-gray-800 text-white p-4 rounded-lg flex items-center justify-center opacity-90 cursor-pointer" onClick={() => handleCardClick(product.id)}>
                       <p className="text-center">{product.description}</p>
                     </div>
                   )}


### PR DESCRIPTION
…roduct instead of the image itself

## Changes
_List Changes Introduced by this PR_
1. Fixed the cards so when clicking on the description it takes to the product page

## Purpose
Users can now navigate to the product page

## Approach
The description was on top of the image so it was hiding the onclick attached to the image

## Learning
N/A

_If this closes an issue, reference the issue here. If it doesn't, remove this line_
Closes #78 
