### PR TITLE
Fix/flippingComponentCards

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "react": "^18.3.1",
     "react-bootstrap": "^2.10.4",
     "react-bootstrap-carousel": "^4.1.1",
-    "react-dom": "^18"
+    "react-dom": "^18",
+    "react-syntax-highlighter": "^15.5.0"
   },
   "devDependencies": {
     "postcss": "^8",

--- a/src/app/components/ComponentsGrid.js
+++ b/src/app/components/ComponentsGrid.js
@@ -24,6 +24,7 @@ const ComponentsGrid = () => {
   </div>
 </nav>
       `,
+      language: "jsx",
     },
     {
       name: "Footer",
@@ -54,6 +55,7 @@ const ComponentsGrid = () => {
   </div>
 </footer>
       `,
+      language: "jsx",
     },
     {
       name: "Hero Section",
@@ -90,6 +92,7 @@ const ComponentsGrid = () => {
   </main>
 </div>
       `,
+      language: "jsx",
     },
     {
       name: "Card",
@@ -126,6 +129,7 @@ const ComponentsGrid = () => {
   </div>
 </div>
       `,
+      language: "jsx",
     },
   ];
 
@@ -140,11 +144,8 @@ const ComponentsGrid = () => {
               <p className="text-gray-600">{component.description}</p>
             </div>
           }
-          backContent={
-            <pre className="p-4 text-sm overflow-auto h-full">
-              <code>{component.code}</code>
-            </pre>
-          }
+          backContent={component.code}
+          language={component.language}
         />
       ))}
     </div>

--- a/src/app/components/FlippingCard.js
+++ b/src/app/components/FlippingCard.js
@@ -1,13 +1,14 @@
 "use client";
-
 import React, { useState } from "react";
+import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
+import { nightOwl } from "react-syntax-highlighter/dist/esm/styles/prism";
 
-const FlippingCard = ({ frontContent, backContent }) => {
+const FlippingCard = ({ frontContent, backContent, language }) => {
   const [isFlipped, setIsFlipped] = useState(false);
 
   return (
     <div
-      className="flip-card w-full h-64 perspective-1000"
+      className="flip-card w-full h-64 perspective-1000 cursor-pointer"
       onClick={() => setIsFlipped(!isFlipped)}
     >
       <div
@@ -16,8 +17,19 @@ const FlippingCard = ({ frontContent, backContent }) => {
         <div className="flip-card-front absolute w-full h-full bg-white shadow-md rounded-lg backface-hidden">
           {frontContent}
         </div>
-        <div className="flip-card-back absolute w-full h-full bg-gray-100 shadow-md rounded-lg backface-hidden rotate-y-180">
-          {backContent}
+        <div className="flip-card-back absolute w-full h-full bg-gray-800 shadow-md rounded-lg backface-hidden rotate-y-180 overflow-auto">
+          <SyntaxHighlighter
+            language={language}
+            style={nightOwl}
+            customStyle={{
+              margin: 0,
+              padding: "1rem",
+              height: "100%",
+              borderRadius: "0.5rem",
+            }}
+          >
+            {backContent}
+          </SyntaxHighlighter>
         </div>
       </div>
     </div>

--- a/src/app/documentation/page.js
+++ b/src/app/documentation/page.js
@@ -223,13 +223,15 @@ export default function DocumentationLayout() {
           </section>
 
           {/* Components Section */}
-          <section id="components">
+          <section id="components" className="mb-8">
             <h2 className="text-3xl font-bold mb-4">Components</h2>
             <p className="text-gray-700 mb-6">
               Here you can find detailed information about the components used
               in the project.
             </p>
-            <ComponentsGrid />
+            <div className="mt-8">
+              <ComponentsGrid />
+            </div>
           </section>
 
           {/* FAQ Section */}


### PR DESCRIPTION
## Images of Changes
![image](https://github.com/user-attachments/assets/296f9e59-6297-44b8-aba9-9ff87600a7c4)
![image](https://github.com/user-attachments/assets/40eb08a9-7036-47ae-8b9c-4075cf86b4e5)

## Changes
1. Implemented modular flipping component cards within the components section of the documentation page.
2. Introduced a flipping animation effect triggered on click.
3. Enhanced the code blocks on the back of the component cards with improved styling.

## Purpose
Ensuring consistent styling for code blocks across all projects.

_Links to blog posts, patterns, libraries or addons used to solve this problem_
[React Syntax Highlighter](https://react-syntax-highlighter.github.io/react-syntax-highlighter/demo/)
[React Syntax Highlighter GitHub](https://github.com/react-syntax-highlighter/react-syntax-highlighter)

## Requested Feedback
Should I include images/screenshots on the front of the cards?
Would it be better to change the background of the documentation page to a darker color to align with the dark mode theme?
Any suggestions for further improving the styling of the cards?